### PR TITLE
Add application-wide undo/redo backed by XML snapshots

### DIFF
--- a/lib/config_change_notifier.dart
+++ b/lib/config_change_notifier.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/foundation.dart';
+
+/// Global callback used to notify the configuration screen that a change
+/// occurred outside of a typical [setState] call (e.g. via [ValueNotifier]).
+VoidCallback? configurationChangeListener;
+
+/// Notify the registered listener that configuration data changed.
+void notifyConfigurationChanged() {
+  final listener = configurationChangeListener;
+  if (listener != null) {
+    listener();
+  }
+}

--- a/lib/globals.dart
+++ b/lib/globals.dart
@@ -1,7 +1,9 @@
-import 'timeswitch.dart';
-import 'package:latlong2/latlong.dart';
 import 'package:flutter/material.dart';
+import 'package:latlong2/latlong.dart';
 import 'package:uuid/uuid.dart';
+
+import 'config_change_notifier.dart';
+import 'timeswitch.dart';
 
 double latitude = 0;
 double longitude = 0;
@@ -90,7 +92,10 @@ class Sector {
   }
 
   String get name => nameNotifier.value;
-  set name(String value) => nameNotifier.value = value;
+  set name(String value) {
+    nameNotifier.value = value;
+    notifyConfigurationChanged();
+  }
 }
 
 class Point {

--- a/lib/timeswitch.dart
+++ b/lib/timeswitch.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:uuid/uuid.dart';
 
+import 'config_change_notifier.dart';
+
 enum CommandType { oneBit, oneByte }
 
 String? validateGroupAddress(String v) {
@@ -54,7 +56,10 @@ class TimeProgram {
   }
 
   String get name => nameNotifier.value;
-  set name(String value) => nameNotifier.value = value;
+  set name(String value) {
+    nameNotifier.value = value;
+    notifyConfigurationChanged();
+  }
 }
 
 class TimeProgramWidget extends StatefulWidget {


### PR DESCRIPTION
## Summary
- introduce an in-memory XML snapshot history with undo and redo stacks on the configuration screen
- wire Ctrl/Cmd+Z and Ctrl/Cmd+Shift+Z shortcuts to the history actions and debounce snapshot recording across the UI
- notify the history manager from sector and time program name edits via a shared configuration change notifier

## Testing
- not run (flutter not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d98144ab38833296c9f1b3ebe57e6e