### PR TITLE
Add undo/redo history across configuration editor

### DIFF
--- a/lib/globals.dart
+++ b/lib/globals.dart
@@ -3,6 +3,8 @@ import 'package:latlong2/latlong.dart';
 import 'package:flutter/material.dart';
 import 'package:uuid/uuid.dart';
 
+import 'history.dart';
+
 double latitude = 0;
 double longitude = 0;
 
@@ -90,7 +92,13 @@ class Sector {
   }
 
   String get name => nameNotifier.value;
-  set name(String value) => nameNotifier.value = value;
+  set name(String value) {
+    if (nameNotifier.value == value) {
+      return;
+    }
+    nameNotifier.value = value;
+    HistoryBinding.requestCapture();
+  }
 }
 
 class Point {

--- a/lib/history.dart
+++ b/lib/history.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+class ConfigHistoryController extends ChangeNotifier {
+  ConfigHistoryController({this.maxEntries = 100});
+
+  final int maxEntries;
+  final List<String> _undoStack = <String>[];
+  final List<String> _redoStack = <String>[];
+  String? _current;
+
+  bool get canUndo => _undoStack.isNotEmpty;
+  bool get canRedo => _redoStack.isNotEmpty;
+
+  void initialize(String snapshot) {
+    _current = snapshot;
+    _undoStack.clear();
+    _redoStack.clear();
+    notifyListeners();
+  }
+
+  void capture(String snapshot) {
+    if (_current == snapshot) {
+      return;
+    }
+    if (_current != null) {
+      _undoStack.add(_current!);
+      if (_undoStack.length > maxEntries) {
+        _undoStack.removeAt(0);
+      }
+    }
+    _current = snapshot;
+    _redoStack.clear();
+    notifyListeners();
+  }
+
+  String? undo() {
+    if (!canUndo) {
+      return null;
+    }
+    final previous = _undoStack.removeLast();
+    if (_current != null) {
+      _redoStack.add(_current!);
+      if (_redoStack.length > maxEntries) {
+        _redoStack.removeAt(0);
+      }
+    }
+    _current = previous;
+    notifyListeners();
+    return _current;
+  }
+
+  String? redo() {
+    if (!canRedo) {
+      return null;
+    }
+    final next = _redoStack.removeLast();
+    if (_current != null) {
+      _undoStack.add(_current!);
+      if (_undoStack.length > maxEntries) {
+        _undoStack.removeAt(0);
+      }
+    }
+    _current = next;
+    notifyListeners();
+    return _current;
+  }
+
+  void replaceCurrent(String snapshot) {
+    _current = snapshot;
+    notifyListeners();
+  }
+}
+
+class HistoryBinding {
+  static VoidCallback? _scheduleCapture;
+
+  static void register(VoidCallback callback) {
+    _scheduleCapture = callback;
+  }
+
+  static void unregister(VoidCallback callback) {
+    if (_scheduleCapture == callback) {
+      _scheduleCapture = null;
+    }
+  }
+
+  static void requestCapture() {
+    final callback = _scheduleCapture;
+    if (callback != null) {
+      callback();
+    }
+  }
+}
+
+mixin HistoryAwareState<T extends StatefulWidget> on State<T> {
+  @protected
+  void markHistoryCaptureNeeded() {
+    HistoryBinding.requestCapture();
+  }
+}

--- a/lib/sector/sector_widget.dart
+++ b/lib/sector/sector_widget.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 
 import 'package:configurator/facade_orientation_dialog.dart';
 import 'package:configurator/globals.dart';
+import 'package:configurator/history.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
@@ -131,7 +132,10 @@ class _SectorWidgetState extends State<SectorWidget> {
     }
   }
 
-  void _mutate(VoidCallback update) => setState(update);
+  void _mutate(VoidCallback update) {
+    setState(update);
+    HistoryBinding.requestCapture();
+  }
 
   void _addHorizonPoint() {
     setState(() {
@@ -143,6 +147,7 @@ class _SectorWidgetState extends State<SectorWidget> {
       _horizonAzErrors[p] = null;
       _horizonElErrors[p] = null;
     });
+    HistoryBinding.requestCapture();
   }
 
   void _addCeilingPoint() {
@@ -155,6 +160,7 @@ class _SectorWidgetState extends State<SectorWidget> {
       _ceilingAzErrors[p] = null;
       _ceilingElErrors[p] = null;
     });
+    HistoryBinding.requestCapture();
   }
 
   List<FlSpot> _computeSolarPath(DateTime date) {
@@ -255,6 +261,7 @@ class _SectorWidgetState extends State<SectorWidget> {
           ..sort((a, b) => a.x.compareTo(b.x));
         _syncPointEditors();
       });
+      HistoryBinding.requestCapture();
 
       if (mounted) {
         ScaffoldMessenger.of(


### PR DESCRIPTION
## Summary
- add a reusable history controller that tracks XML snapshots in memory
- integrate undo/redo shortcuts and snapshot application inside the configuration screen
- trigger history captures from sector and time program editors so all edits participate in undo/redo

## Testing
- not run (Flutter tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d98144ab38833296c9f1b3ebe57e6e