### PR TITLE
Add undo/redo support via XML history snapshots

### DIFF
--- a/lib/sector/sector_widget.dart
+++ b/lib/sector/sector_widget.dart
@@ -25,7 +25,13 @@ class _CsvSectorData {
 class SectorWidget extends StatefulWidget {
   final Sector sector;
   final VoidCallback onRemove;
-  const SectorWidget({super.key, required this.sector, required this.onRemove});
+  final VoidCallback onChanged;
+  const SectorWidget({
+    super.key,
+    required this.sector,
+    required this.onRemove,
+    required this.onChanged,
+  });
 
   @override
   State<SectorWidget> createState() => _SectorWidgetState();
@@ -73,6 +79,13 @@ class _SectorWidgetState extends State<SectorWidget> {
   bool _isImporting = false;
 
   @override
+  void setState(VoidCallback fn) {
+    if (!mounted) return;
+    super.setState(fn);
+    widget.onChanged();
+  }
+
+  @override
   void initState() {
     super.initState();
     _orientationController = TextEditingController(
@@ -83,10 +96,23 @@ class _SectorWidgetState extends State<SectorWidget> {
     _ceilingAzController = TextEditingController();
     _ceilingElController = TextEditingController();
     _syncPointEditors();
+    sector.nameNotifier.addListener(widget.onChanged);
+  }
+
+  @override
+  void didUpdateWidget(covariant SectorWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.sector != widget.sector) {
+      oldWidget.sector.nameNotifier.removeListener(widget.onChanged);
+      sector.nameNotifier.addListener(widget.onChanged);
+      _orientationController.text = sector.orientation.toStringAsFixed(1);
+      _syncPointEditors();
+    }
   }
 
   @override
   void dispose() {
+    sector.nameNotifier.removeListener(widget.onChanged);
     _orientationController.dispose();
     _horizonAzController.dispose();
     _horizonElController.dispose();

--- a/lib/timeswitch.dart
+++ b/lib/timeswitch.dart
@@ -60,13 +60,47 @@ class TimeProgram {
 class TimeProgramWidget extends StatefulWidget {
   final TimeProgram program;
   final VoidCallback onRemove;
-  const TimeProgramWidget({super.key, required this.program, required this.onRemove});
+  final VoidCallback onChanged;
+  const TimeProgramWidget({
+    super.key,
+    required this.program,
+    required this.onRemove,
+    required this.onChanged,
+  });
 
   @override
   State<TimeProgramWidget> createState() => _TimeProgramWidgetState();
 }
 
 class _TimeProgramWidgetState extends State<TimeProgramWidget> {
+  @override
+  void setState(VoidCallback fn) {
+    if (!mounted) return;
+    super.setState(fn);
+    widget.onChanged();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    widget.program.nameNotifier.addListener(widget.onChanged);
+  }
+
+  @override
+  void didUpdateWidget(covariant TimeProgramWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.program != widget.program) {
+      oldWidget.program.nameNotifier.removeListener(widget.onChanged);
+      widget.program.nameNotifier.addListener(widget.onChanged);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.program.nameNotifier.removeListener(widget.onChanged);
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     return SingleChildScrollView(
@@ -86,7 +120,9 @@ class _TimeProgramWidgetState extends State<TimeProgramWidget> {
               return TextFormField(
                 initialValue: name,
                 decoration: const InputDecoration(labelText: 'Name'),
-                onChanged: (v) => widget.program.name = v,
+                onChanged: (v) {
+                  widget.program.name = v;
+                },
               );
             },
           ),
@@ -123,6 +159,7 @@ class _TimeProgramWidgetState extends State<TimeProgramWidget> {
               key: ObjectKey(widget.program.commands[i]),
               command: widget.program.commands[i],
               onRemove: () => setState(() => widget.program.commands.removeAt(i)),
+              onChanged: widget.onChanged,
             ),
           const SizedBox(height: 16),
           Align(
@@ -142,7 +179,13 @@ class _TimeProgramWidgetState extends State<TimeProgramWidget> {
 class _CommandCard extends StatefulWidget {
   final TimeCommand command;
   final VoidCallback onRemove;
-  const _CommandCard({super.key, required this.command, required this.onRemove});
+  final VoidCallback onChanged;
+  const _CommandCard({
+    super.key,
+    required this.command,
+    required this.onRemove,
+    required this.onChanged,
+  });
 
   @override
   State<_CommandCard> createState() => _CommandCardState();
@@ -162,6 +205,13 @@ class _CommandCardState extends State<_CommandCard> {
     _byteError = null;
     _gaError = widget.command.groupAddress.isEmpty ? null : validateGroupAddress(widget.command.groupAddress);
     _gaController = TextEditingController(text: widget.command.groupAddress);
+  }
+
+  @override
+  void setState(VoidCallback fn) {
+    if (!mounted) return;
+    super.setState(fn);
+    widget.onChanged();
   }
 
   @override
@@ -214,7 +264,10 @@ class _CommandCardState extends State<_CommandCard> {
                     const SizedBox(width: 12),
                     _TimeField(
                       initial: c.time,
-                      onChanged: (v) => c.time = v,
+                      onChanged: (v) {
+                        c.time = v;
+                        widget.onChanged();
+                      },
                     ),
                   ],
                 ),

--- a/lib/undo_manager.dart
+++ b/lib/undo_manager.dart
@@ -1,0 +1,48 @@
+class UndoRedoManager {
+  final List<String> _history = <String>[];
+  int _currentIndex = -1;
+  bool _isApplying = false;
+
+  bool get isApplying => _isApplying;
+
+  set isApplying(bool value) => _isApplying = value;
+
+  bool get canUndo => _currentIndex > 0;
+  bool get canRedo => _currentIndex >= 0 && _currentIndex < _history.length - 1;
+  bool get hasEntries => _history.isNotEmpty;
+
+  void clear() {
+    _history.clear();
+    _currentIndex = -1;
+  }
+
+  void initialize(String initialState) {
+    clear();
+    _history.add(initialState);
+    _currentIndex = 0;
+  }
+
+  void capture(String state) {
+    if (_isApplying) return;
+    if (_history.isNotEmpty && _history[_currentIndex] == state) {
+      return;
+    }
+    if (_currentIndex < _history.length - 1) {
+      _history.removeRange(_currentIndex + 1, _history.length);
+    }
+    _history.add(state);
+    _currentIndex = _history.length - 1;
+  }
+
+  String? undo() {
+    if (!canUndo) return null;
+    _currentIndex -= 1;
+    return _history[_currentIndex];
+  }
+
+  String? redo() {
+    if (!canRedo) return null;
+    _currentIndex += 1;
+    return _history[_currentIndex];
+  }
+}


### PR DESCRIPTION
## Summary
- add an in-memory undo/redo manager that stores XML snapshots of the project and expose it through keyboard shortcuts
- track configuration mutations across general settings, sectors, and time programs so changes notify the history manager

## Testing
- not run (Flutter tooling not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d98144ab38833296c9f1b3ebe57e6e