### PR TITLE
Add undo/redo support backed by XML history

### DIFF
--- a/lib/sector/horizon_tab.dart
+++ b/lib/sector/horizon_tab.dart
@@ -13,7 +13,7 @@ extension _HorizonLimitTab on _SectorWidgetState {
               onPressed: () {
                 _mutate(() {
                   _selectedDate = DateTime.now();
-                });
+                }, notify: false);
               },
               child: const Text('Heute'),
             ),
@@ -28,7 +28,7 @@ extension _HorizonLimitTab on _SectorWidgetState {
                 if (picked != null) {
                   _mutate(() {
                     _selectedDate = picked;
-                  });
+                  }, notify: false);
                 }
               },
               child: const Text('Datum wählen'),
@@ -114,9 +114,11 @@ extension _HorizonLimitTab on _SectorWidgetState {
                                 });
                               },
                               onAzErrorChange: (p, err) =>
-                                  _mutate(() => _horizonAzErrors[p] = err),
+                                  _mutate(() => _horizonAzErrors[p] = err,
+                                      notify: false),
                               onElErrorChange: (p, err) =>
-                                  _mutate(() => _horizonElErrors[p] = err),
+                                  _mutate(() => _horizonElErrors[p] = err,
+                                      notify: false),
                             ),
                             const Divider(height: 24),
                             Row(
@@ -158,9 +160,11 @@ extension _HorizonLimitTab on _SectorWidgetState {
                                 });
                               },
                               onAzErrorChange: (p, err) =>
-                                  _mutate(() => _ceilingAzErrors[p] = err),
+                                  _mutate(() => _ceilingAzErrors[p] = err,
+                                      notify: false),
                               onElErrorChange: (p, err) =>
-                                  _mutate(() => _ceilingElErrors[p] = err),
+                                  _mutate(() => _ceilingElErrors[p] = err,
+                                      notify: false),
                             ),
                             const SizedBox(height: 16),
                             TextButton.icon(

--- a/lib/sector/louvre_tab.dart
+++ b/lib/sector/louvre_tab.dart
@@ -64,15 +64,24 @@ extension _LouvreTab on _SectorWidgetState {
                 onChanged: (v) {
                   final val = _parseLocalizedDouble(v);
                   if (val == null) {
-                    _mutate(() => _louvreAngleZeroError = 'Bitte einen gültigen Winkel eingeben');
+                    _mutate(
+                        () => _louvreAngleZeroError =
+                            'Bitte einen gültigen Winkel eingeben',
+                        notify: false);
                     return;
                   }
                   if (val < 0 || val > 90) {
-                    _mutate(() => _louvreAngleZeroError = 'Wert muss zwischen 0° und 90° liegen');
+                    _mutate(
+                        () => _louvreAngleZeroError =
+                            'Wert muss zwischen 0° und 90° liegen',
+                        notify: false);
                     return;
                   }
                   if (val <= sector.louvreAngleAtHundred) {
-                    _mutate(() => _louvreAngleZeroError = 'Wert muss grösser als Winkel bei 100% sein');
+                    _mutate(
+                        () => _louvreAngleZeroError =
+                            'Wert muss grösser als Winkel bei 100% sein',
+                        notify: false);
                     return;
                   }
                   _mutate(() {
@@ -99,15 +108,24 @@ extension _LouvreTab on _SectorWidgetState {
                 onChanged: (v) {
                   final val = _parseLocalizedDouble(v);
                   if (val == null) {
-                    _mutate(() => _louvreAngleHundredError = 'Bitte einen gültigen Winkel eingeben');
+                    _mutate(
+                        () => _louvreAngleHundredError =
+                            'Bitte einen gültigen Winkel eingeben',
+                        notify: false);
                     return;
                   }
                   if (val < 0 || val > 90) {
-                    _mutate(() => _louvreAngleHundredError = 'Wert muss zwischen 0° und 90° liegen');
+                    _mutate(
+                        () => _louvreAngleHundredError =
+                            'Wert muss zwischen 0° und 90° liegen',
+                        notify: false);
                     return;
                   }
                   if (val >= sector.louvreAngleAtZero) {
-                    _mutate(() => _louvreAngleHundredError = 'Wert muss kleiner als Winkel bei 0% sein');
+                    _mutate(
+                        () => _louvreAngleHundredError =
+                            'Wert muss kleiner als Winkel bei 0% sein',
+                        notify: false);
                     return;
                   }
                   _mutate(() {
@@ -134,11 +152,17 @@ extension _LouvreTab on _SectorWidgetState {
                 onChanged: (v) {
                   final val = _parseLocalizedDouble(v);
                   if (val == null) {
-                    _mutate(() => _louvreMinimumChangeError = 'Bitte eine Zahl zwischen 0% und 100% eingeben');
+                    _mutate(
+                        () => _louvreMinimumChangeError =
+                            'Bitte eine Zahl zwischen 0% und 100% eingeben',
+                        notify: false);
                     return;
                   }
                   if (val < 0 || val > 100) {
-                    _mutate(() => _louvreMinimumChangeError = 'Wert muss zwischen 0% und 100% liegen');
+                    _mutate(
+                        () => _louvreMinimumChangeError =
+                            'Wert muss zwischen 0% und 100% liegen',
+                        notify: false);
                     return;
                   }
                   _mutate(() {
@@ -162,11 +186,17 @@ extension _LouvreTab on _SectorWidgetState {
                 onChanged: (v) {
                   final val = _parseLocalizedDouble(v);
                   if (val == null) {
-                    _mutate(() => _louvreBufferError = 'Bitte eine Zahl zwischen 0% und 100% eingeben');
+                    _mutate(
+                        () => _louvreBufferError =
+                            'Bitte eine Zahl zwischen 0% und 100% eingeben',
+                        notify: false);
                     return;
                   }
                   if (val < 0 || val > 100) {
-                    _mutate(() => _louvreBufferError = 'Wert muss zwischen 0% und 100% liegen');
+                    _mutate(
+                        () => _louvreBufferError =
+                            'Wert muss zwischen 0% und 100% liegen',
+                        notify: false);
                     return;
                   }
                   _mutate(() {
@@ -231,7 +261,7 @@ extension _LouvreTab on _SectorWidgetState {
                 onChanged: (value) {
                   _mutate(() {
                     _louvrePreviewPercent = value;
-                  });
+                  }, notify: false);
                 },
               ),
               Align(

--- a/lib/sector/sector_widget.dart
+++ b/lib/sector/sector_widget.dart
@@ -25,7 +25,13 @@ class _CsvSectorData {
 class SectorWidget extends StatefulWidget {
   final Sector sector;
   final VoidCallback onRemove;
-  const SectorWidget({super.key, required this.sector, required this.onRemove});
+  final VoidCallback onChanged;
+  const SectorWidget({
+    super.key,
+    required this.sector,
+    required this.onRemove,
+    required this.onChanged,
+  });
 
   @override
   State<SectorWidget> createState() => _SectorWidgetState();
@@ -131,10 +137,15 @@ class _SectorWidgetState extends State<SectorWidget> {
     }
   }
 
-  void _mutate(VoidCallback update) => setState(update);
+  void _mutate(VoidCallback update, {bool notify = true}) {
+    setState(update);
+    if (notify) {
+      widget.onChanged();
+    }
+  }
 
   void _addHorizonPoint() {
-    setState(() {
+    _mutate(() {
       final p = Point(x: 0, y: 0);
       sector.horizonPoints.add(p);
       sector.horizonPoints.sort((a, b) => a.x.compareTo(b.x));
@@ -146,7 +157,7 @@ class _SectorWidgetState extends State<SectorWidget> {
   }
 
   void _addCeilingPoint() {
-    setState(() {
+    _mutate(() {
       final p = Point(x: 0, y: 0);
       sector.ceilingPoints.add(p);
       sector.ceilingPoints.sort((a, b) => a.x.compareTo(b.x));
@@ -224,7 +235,7 @@ class _SectorWidgetState extends State<SectorWidget> {
       if (selected == null) return; // canceled
 
       final data = parsed[selected]!;
-      setState(() {
+      _mutate(() {
         // Replace existing points with imported ones
         // Clear controllers to avoid leaks for removed points
         for (final c in _horizonAzCtrls.values) {

--- a/lib/sector/settings_tab.dart
+++ b/lib/sector/settings_tab.dart
@@ -23,6 +23,7 @@ extension _SettingsTab on _SectorWidgetState {
                 decoration: const InputDecoration(labelText: 'Name'),
                 onChanged: (v) {
                   sector.name = v;
+                  widget.onChanged();
                 },
               );
             },
@@ -45,7 +46,7 @@ extension _SettingsTab on _SectorWidgetState {
                       _mutate(() {
                         _orientationError =
                             'Bitte Wert zwischen -180 und 180 eingeben';
-                      });
+                      }, notify: false);
                     } else {
                       _mutate(() {
                         _orientationError = null;
@@ -168,7 +169,7 @@ extension _SettingsTab on _SectorWidgetState {
                   _mutate(() {
                     _brightnessUpperThresholdError =
                         'Bitte gültigen Wert eingeben';
-                  });
+                  }, notify: false);
                 } else {
                   _mutate(() {
                     _brightnessUpperThresholdError = null;
@@ -191,7 +192,7 @@ extension _SettingsTab on _SectorWidgetState {
                 if (val == null || val < 0) {
                   _mutate(() {
                     _brightnessUpperDelayError = 'Bitte gültigen Wert eingeben';
-                  });
+                  }, notify: false);
                 } else {
                   _mutate(() {
                     _brightnessUpperDelayError = null;
@@ -215,7 +216,7 @@ extension _SettingsTab on _SectorWidgetState {
                   _mutate(() {
                     _brightnessLowerThresholdError =
                         'Bitte gültigen Wert eingeben';
-                  });
+                  }, notify: false);
                 } else {
                   _mutate(() {
                     _brightnessLowerThresholdError = null;
@@ -238,7 +239,7 @@ extension _SettingsTab on _SectorWidgetState {
                 if (val == null || val < 0) {
                   _mutate(() {
                     _brightnessLowerDelayError = 'Bitte gültigen Wert eingeben';
-                  });
+                  }, notify: false);
                 } else {
                   _mutate(() {
                     _brightnessLowerDelayError = null;
@@ -298,7 +299,7 @@ extension _SettingsTab on _SectorWidgetState {
                   _mutate(() {
                     _irradianceUpperThresholdError =
                         'Bitte gültigen Wert eingeben';
-                  });
+                  }, notify: false);
                 } else {
                   _mutate(() {
                     _irradianceUpperThresholdError = null;
@@ -321,7 +322,7 @@ extension _SettingsTab on _SectorWidgetState {
                 if (val == null || val < 0) {
                   _mutate(() {
                     _irradianceUpperDelayError = 'Bitte gültigen Wert eingeben';
-                  });
+                  }, notify: false);
                 } else {
                   _mutate(() {
                     _irradianceUpperDelayError = null;
@@ -345,7 +346,7 @@ extension _SettingsTab on _SectorWidgetState {
                   _mutate(() {
                     _irradianceLowerThresholdError =
                         'Bitte gültigen Wert eingeben';
-                  });
+                  }, notify: false);
                 } else {
                   _mutate(() {
                     _irradianceLowerThresholdError = null;
@@ -368,7 +369,7 @@ extension _SettingsTab on _SectorWidgetState {
                 if (val == null || val < 0) {
                   _mutate(() {
                     _irradianceLowerDelayError = 'Bitte gültigen Wert eingeben';
-                  });
+                  }, notify: false);
                 } else {
                   _mutate(() {
                     _irradianceLowerDelayError = null;

--- a/lib/timeswitch.dart
+++ b/lib/timeswitch.dart
@@ -60,7 +60,13 @@ class TimeProgram {
 class TimeProgramWidget extends StatefulWidget {
   final TimeProgram program;
   final VoidCallback onRemove;
-  const TimeProgramWidget({super.key, required this.program, required this.onRemove});
+  final VoidCallback onChanged;
+  const TimeProgramWidget({
+    super.key,
+    required this.program,
+    required this.onRemove,
+    required this.onChanged,
+  });
 
   @override
   State<TimeProgramWidget> createState() => _TimeProgramWidgetState();
@@ -86,7 +92,10 @@ class _TimeProgramWidgetState extends State<TimeProgramWidget> {
               return TextFormField(
                 initialValue: name,
                 decoration: const InputDecoration(labelText: 'Name'),
-                onChanged: (v) => widget.program.name = v,
+                onChanged: (v) {
+                  widget.program.name = v;
+                  widget.onChanged();
+                },
               );
             },
           ),
@@ -98,12 +107,16 @@ class _TimeProgramWidgetState extends State<TimeProgramWidget> {
               IconButton(
                 icon: const Icon(Icons.add),
                 tooltip: 'Befehl hinzufügen',
-                onPressed: () => setState(() {
-                  final defaultGa = widget.program.commands.isNotEmpty
-                      ? widget.program.commands.last.groupAddress
-                      : '';
-                  widget.program.commands.add(TimeCommand(groupAddress: defaultGa));
-                }),
+                onPressed: () {
+                  setState(() {
+                    final defaultGa = widget.program.commands.isNotEmpty
+                        ? widget.program.commands.last.groupAddress
+                        : '';
+                    widget.program.commands
+                        .add(TimeCommand(groupAddress: defaultGa));
+                  });
+                  widget.onChanged();
+                },
               ),
             ],
           ),
@@ -122,7 +135,11 @@ class _TimeProgramWidgetState extends State<TimeProgramWidget> {
             _CommandCard(
               key: ObjectKey(widget.program.commands[i]),
               command: widget.program.commands[i],
-              onRemove: () => setState(() => widget.program.commands.removeAt(i)),
+              onChanged: widget.onChanged,
+              onRemove: () {
+                setState(() => widget.program.commands.removeAt(i));
+                widget.onChanged();
+              },
             ),
           const SizedBox(height: 16),
           Align(
@@ -142,7 +159,13 @@ class _TimeProgramWidgetState extends State<TimeProgramWidget> {
 class _CommandCard extends StatefulWidget {
   final TimeCommand command;
   final VoidCallback onRemove;
-  const _CommandCard({super.key, required this.command, required this.onRemove});
+  final VoidCallback onChanged;
+  const _CommandCard({
+    super.key,
+    required this.command,
+    required this.onRemove,
+    required this.onChanged,
+  });
 
   @override
   State<_CommandCard> createState() => _CommandCardState();
@@ -193,6 +216,7 @@ class _CommandCardState extends State<_CommandCard> {
                   widget.command.groupAddress = v;
                   _gaError = validateGroupAddress(v);
                 });
+                widget.onChanged();
               },
             ),
             const SizedBox(height: 12),
@@ -203,18 +227,25 @@ class _CommandCardState extends State<_CommandCard> {
                   children: [
                     _TypeDropdown(
                       value: c.type,
-                      onChanged: (t) => setState(() {
-                        c.type = t;
-                        if (c.type == CommandType.oneByte) {
-                          _byteController.text = c.value.clamp(0, 255).toString();
-                          _byteError = null;
-                        }
-                      }),
+                      onChanged: (t) {
+                        setState(() {
+                          c.type = t;
+                          if (c.type == CommandType.oneByte) {
+                            _byteController.text =
+                                c.value.clamp(0, 255).toString();
+                            _byteError = null;
+                          }
+                        });
+                        widget.onChanged();
+                      },
                     ),
                     const SizedBox(width: 12),
                     _TimeField(
                       initial: c.time,
-                      onChanged: (v) => c.time = v,
+                      onChanged: (v) {
+                        c.time = v;
+                        widget.onChanged();
+                      },
                     ),
                   ],
                 ),
@@ -234,25 +265,40 @@ class _CommandCardState extends State<_CommandCard> {
                   FilterChip(
                     label: Text(_days[i]),
                     selected: _isDaySelected(c.weekdaysMask, i),
-                    onSelected: (sel) => setState(() {
-                      c.weekdaysMask = _toggleDay(c.weekdaysMask, i);
-                    }),
+                    onSelected: (sel) {
+                      setState(() {
+                        c.weekdaysMask = _toggleDay(c.weekdaysMask, i);
+                      });
+                      widget.onChanged();
+                    },
                   ),
                 const SizedBox(width: 12),
                 TextButton(
-                  onPressed: () => setState(() => c.weekdaysMask = _maskForWeekdays()),
+                  onPressed: () {
+                    setState(() => c.weekdaysMask = _maskForWeekdays());
+                    widget.onChanged();
+                  },
                   child: const Text('Wochentage'),
                 ),
                 TextButton(
-                  onPressed: () => setState(() => c.weekdaysMask = _maskForWeekend()),
+                  onPressed: () {
+                    setState(() => c.weekdaysMask = _maskForWeekend());
+                    widget.onChanged();
+                  },
                   child: const Text('Wochenende'),
                 ),
                 TextButton(
-                  onPressed: () => setState(() => c.weekdaysMask = _maskForAll()),
+                  onPressed: () {
+                    setState(() => c.weekdaysMask = _maskForAll());
+                    widget.onChanged();
+                  },
                   child: const Text('Alle'),
                 ),
                 TextButton(
-                  onPressed: () => setState(() => c.weekdaysMask = 0),
+                  onPressed: () {
+                    setState(() => c.weekdaysMask = 0);
+                    widget.onChanged();
+                  },
                   child: const Text('Keine'),
                 ),
               ],
@@ -265,7 +311,10 @@ class _CommandCardState extends State<_CommandCard> {
                   const SizedBox(width: 8),
                   Switch(
                     value: c.value == 1,
-                    onChanged: (v) => setState(() => c.value = v ? 1 : 0),
+                    onChanged: (v) {
+                      setState(() => c.value = v ? 1 : 0);
+                      widget.onChanged();
+                    },
                   ),
                   const SizedBox(width: 4),
                   Text(c.value == 1 ? 'Ein (1)' : 'Aus (0)'),
@@ -300,6 +349,9 @@ class _CommandCardState extends State<_CommandCard> {
                                 c.value = n;
                               }
                             });
+                            if (n != null && n >= 0 && n <= 255) {
+                              widget.onChanged();
+                            }
                           },
                         ),
                       ),
@@ -310,12 +362,15 @@ class _CommandCardState extends State<_CommandCard> {
                           max: 255,
                           divisions: 255,
                           value: c.value.clamp(0, 255).toDouble(),
-                          onChanged: (v) => setState(() {
-                            c.value = v.round();
-                            _byteError = null;
-                            // keep text field in sync when sliding
-                            _byteController.text = c.value.toString();
-                          }),
+                          onChanged: (v) {
+                            setState(() {
+                              c.value = v.round();
+                              _byteError = null;
+                              // keep text field in sync when sliding
+                              _byteController.text = c.value.toString();
+                            });
+                            widget.onChanged();
+                          },
                         ),
                       ),
                     ],


### PR DESCRIPTION
## Summary
- add undo/redo stacks that capture XML snapshots and wire them to lifecycle events and keyboard shortcuts
- notify the history manager from sector and time program editors while suppressing UI-only mutations
- update configuration actions (add/paste/remove and bus address edits) to participate in the undo history

## Testing
- not run (environment does not have Flutter/Dart tooling available)


------
https://chatgpt.com/codex/tasks/task_e_68d98144ab38833296c9f1b3ebe57e6e